### PR TITLE
修改workflow定时任务以及部署指南勘误

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,7 +3,7 @@ name: TodoSync
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 7-23/1 * * *'
+    - cron: '0 22,3,11 * * *'
 
 jobs:
   sync:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,7 +3,7 @@ name: TodoSync
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 22,3,11 * * *'
+    - cron: '0 0-14/1,22,23 * * *'
 
 jobs:
   sync:

--- a/docs/actions-persis.md
+++ b/docs/actions-persis.md
@@ -39,9 +39,9 @@
 
 ### 二、配置 Graph Token
 
-下面以 Windows 系统为例，借助“Graph 认证辅助工具”（在本仓库开源）进行配置。如有其它需求，可参考[手动配置 Graph Token](./graph-token-manually.md)
+下面以 Windows 系统为例，借助“Graph 认证辅助工具”（在本仓库开源）进行配置。如有其它需求，可参考[手动配置 Graph Token](./graph-token-mannui.md)
 
-10. 在 [Releases](https://github.com/1357310795/TodoSynchronizer/releases) 页面下载“TodoSynchronizer.QuickTool.exe”，打开。
+10. 在 [Releases](../../../releases) 页面下载“TodoSynchronizer.QuickTool.exe”，打开。
 
 11. 点击“获取 Graph 认证”，跳转到浏览器
 


### PR DESCRIPTION
GitHub workflow的时间采用UTC时间，比北京时间晚8小时，再加上GitHub workflow的高负载，实际可能相差9小时左右。原有写法会导致workflow在凌晨不必要时间运行。